### PR TITLE
chore(CI): Setup GitHub Actions workflow for Docker image build and push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+  pull_request:
+    branches:
+      - main
+      - develop
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: docker/setup-buildx-action@v3
+      with:
+        platforms: linux/amd64,linux/arm64
+    
+    - name: Login to Docker DockerHub
+      uses: docker/login-action@v3
+      if: ${{ github.event_name != 'pull_request' }}
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Prepare Docker tags
+      run: |
+        TAG=latest
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          TAG=${GITHUB_REF#refs/tags/}
+        fi
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        push: ${{ github.event_name != 'pull_request' }}
+        platforms: linux/amd64,linux/arm64
+        labels: |
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        tags: |
+          ${{ secrets.DOCKER_USERNAME }}/dify2openai:${{ env.TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+!.github


### PR DESCRIPTION
## Background

To enhance our development and deployment efficiency, we need an automated process to build Docker images and push them to DockerHub. This will ensure our images are always in sync with our codebase and can be easily deployed across different environments.

## Proposal

I propose implementing a GitHub Actions workflow that will automatically build Docker images and push them to DockerHub under specific conditions.

### Key Features

1. Trigger builds on pushes to the `main` branch or when new tags are created.
2. Support build checks for Pull Requests.
3. Allow manual triggering of builds (via `workflow_dispatch`).
4. Build multi-architecture images (linux/amd64 and linux/arm64).
5. Determine whether to push images based on the event type.
6. Use semantic versioning tags and a `latest` tag.

## Requirements 

The repository owner needs to configure secrets, including DOCKER_USERNAME and DOCKER_PASSWORD.
